### PR TITLE
FIX t10375 - do not update a task's declared progress upon adding time spent

### DIFF
--- a/ajax/interface.php
+++ b/ajax/interface.php
@@ -279,9 +279,7 @@ function _stopTask(&$PDOdb,$taskId,$hour,$minutes,$id_user_selected=0){
 				$ttemp['total_duration']+= $task->timespent_duration;
 
 				if($task->planned_workload>0) {
-				    $task->progress = round(round($ttemp['total_duration'] / $task->planned_workload * 100) / 5) * 5;
-				    if($task->progress < 5) $task->progress = 5;
-				    else if ($task->progress > 100) $task->progress = 100;
+				    if ($task->progress === null) $task->progress = 0;
 				}
 
 				$task->add_contact($user->id, 180, 'internal');


### PR DESCRIPTION
The current behavior makes it possible for tasks to reach 100% declared progress even though they are not finished (and as they reach 100%, they are no longer listed).
This fix does not change anything to the calculated progress (which will still be calculated using time spent over scheduled time); however, the declared progress will no longer be updated automatically.