### PR TITLE
Fix 2.3 en us translations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,7 @@
+# CHANGELOG FOR TASKLIST MODULE
+
+## Not Released
+
+## 2.3
+- FIX : en_US translation - *19/04/2021* - 2.3.1
+- No changelog up to this point

--- a/core/modules/modtasklist.class.php
+++ b/core/modules/modtasklist.class.php
@@ -59,7 +59,7 @@ class modtasklist extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module tasklist";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.3.0';
+		$this->version = '2.3.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/langs/en_US/tasklist.lang
+++ b/langs/en_US/tasklist.lang
@@ -8,3 +8,36 @@ tasklistAbout = About tasklist
 
 TASKLIST_SHOW_DESCRIPTION_TASK=Show task description
 TASKLIST_ONLY_ADMIN_CAN_CHANGE_USER=Only admin can change user in tasklist screen
+
+Module104590Name = tasklist
+Module104590Desc = Vue dédiée à l'atelier
+
+ATMAbout = Ce module a été développé par <a href="http://www.atm-consulting.fr" target="_blank">ATM Consulting</a><br>Vous pouvez retrouver la documentation sur notre <a href="http://wiki.atm-consulting.fr/index.php/Accueil" target="_blank">wiki</a><br><br>Pour toute question technique ou retour, contactez-nous sur <a href="mailto:support@atm-consulting.fr">support@atm-consulting.fr</a><br><br>Pour toute question commerciale, contactez-nous sur <a href="mailto:contact@atm-consulting.fr">contact@atm-consulting.fr</a> ou au +33 9 77 19 50 70<br><br>Retrouvez nos autres modules sur <a href="http://www.dolistore.com/search.php?orderby=position&orderway=desc&search_query=atm&submit_search=Rechercher" target="_blank">Dolistore</a>
+
+tasklistSetup = Configuration du module tasklist
+tasklistAbout = A propos du module tasklist
+
+Tasklist = Tâches à réaliser
+
+#Liste des tâches
+Task = Tâche
+Tasks=Tâches
+DateStart = Date début
+DateEnd = Date fin
+ExpectedTime = Temps prévu (h)
+PastTime = Temps passé (h)
+Progress = Progression
+Priority = Priorité
+Start = Démarrer
+Pause = Mettre en pause
+Close = Terminer
+All=Tous
+
+TASKLIST_SHOW_DOCPREVIEW=Afficher les icônes de prévisualisations des documents associés à la commande d'origine sur la liste des tâches
+TASKLIST_SHOW_EXTRAFIELDS=Afficher les extrafields des tâches
+TASKLIST_SHOW_LINE_ORDER_EXTRAFIELD_JUST_THEM=Limiter l'affichage au extrafield suivant
+TASKLIST_OF_LINK_TO_DOLIBARR=Le lien OF redirige sur la fiche dolibarr standard (si droit possédé par l'utilisateur)
+AllowToUseDolibarrOFRedirection=Rediriger sur la fiche OF de Dolibarr
+AllowToChangeTaskPercent=Permettre de changer le pourcentage des tâches
+TASKLIST_SHOW_DESCRIPTION_TASK=Afficher la description des tâches
+TASKLIST_ONLY_ADMIN_CAN_CHANGE_USER=Seuls les administrateurs peuvent changer d'utilisateur sur l'écran tasklist

--- a/langs/fr_FR/tasklist.lang
+++ b/langs/fr_FR/tasklist.lang
@@ -24,7 +24,7 @@ All=Tous
 
 TASKLIST_SHOW_DOCPREVIEW=Afficher les icônes de prévisualisations des documents associés à la commande d'origine sur la liste des tâches
 TASKLIST_SHOW_EXTRAFIELDS=Afficher les extrafields des tâches
-TASKLIST_SHOW_LINE_ORDER_EXTRAFIELD_JUST_THEM=N’afficher que les champs complémentaires suivants :
+TASKLIST_SHOW_LINE_ORDER_EXTRAFIELD_JUST_THEM=Afficher uniquement les champs complémentaires suivants :
 TASKLIST_OF_LINK_TO_DOLIBARR=Le lien OF redirige sur la fiche dolibarr standard (si droit possédé par l'utilisateur)
 AllowToUseDolibarrOFRedirection=Rediriger sur la fiche OF de Dolibarr
 AllowToChangeTaskPercent=Permettre de changer le pourcentage des tâches

--- a/langs/fr_FR/tasklist.lang
+++ b/langs/fr_FR/tasklist.lang
@@ -24,7 +24,7 @@ All=Tous
 
 TASKLIST_SHOW_DOCPREVIEW=Afficher les icônes de prévisualisations des documents associés à la commande d'origine sur la liste des tâches
 TASKLIST_SHOW_EXTRAFIELDS=Afficher les extrafields des tâches
-TASKLIST_SHOW_LINE_ORDER_EXTRAFIELD_JUST_THEM=Limiter l'affichage au extrafield suivant
+TASKLIST_SHOW_LINE_ORDER_EXTRAFIELD_JUST_THEM=N’afficher que les champs complémentaires suivants :
 TASKLIST_OF_LINK_TO_DOLIBARR=Le lien OF redirige sur la fiche dolibarr standard (si droit possédé par l'utilisateur)
 AllowToUseDolibarrOFRedirection=Rediriger sur la fiche OF de Dolibarr
 AllowToChangeTaskPercent=Permettre de changer le pourcentage des tâches


### PR DESCRIPTION
# FIX (DA020070)
- FIX : en_US translation - *19/04/2021* - 2.3.1
- J’ai créé le ChangeLog.

⚠ Actuellement, la branche 2.0 est une branche "ancienne méthode" (elle contient la 2.3, comme la master). Je me suis un peu fait avoir, mais c’est bon maintenant…